### PR TITLE
minor adjustments

### DIFF
--- a/lib/theme.ex
+++ b/lib/theme.ex
@@ -46,6 +46,7 @@ defmodule AnsiToHTML.Theme do
     "\e[35m": {:span, [style: "color: magenta;"]},
     "\e[36m": {:span, [style: "color: cyan;"]},
     "\e[37m": {:span, [style: "color: white;"]},
+    "\e[39m": {:text, []}, # default to the text color in browser
     "\e[40m": {:span, [style: "background-color: black;"]},
     "\e[41m": {:span, [style: "background-color: red;"]},
     "\e[42m": {:span, [style: "background-color: green;"]},
@@ -54,6 +55,14 @@ defmodule AnsiToHTML.Theme do
     "\e[45m": {:span, [style: "background-color: magenta;"]},
     "\e[46m": {:span, [style: "background-color: cyan;"]},
     "\e[47m": {:span, [style: "background-color: white;"]},
-    "\e[49m": {:span, [style: "background-color: black;"]},
+    "\e[49m": {:span, [style: "background-color: black;"]}
   )
+
+  def new(attrs) when is_list(attrs), do: new(Map.new(attrs))
+
+  def new(attrs) when is_map(attrs) do
+    %__MODULE__{}
+    |> Map.from_struct()
+    |> Map.merge(attrs)
+  end
 end


### PR DESCRIPTION
This may be a stale project, but its actually really useful to me right now (thanks! ❤️).

Here are a few fixes that I was running into for my use cases. It may help others

* Allows you to specify `container: :none` in the theme so it just produces
content tags outside of a container. Specially, this helps for the cases of
wanting to just format a single line and add to an existing container, like
via Phoenix.LiveView
* changes how the ANSI codes are parsed and chunked so that it only colors
the expected text and not the whole line that color is on
* Adds `\e[39m` to default theme which is `default_color` and just specifies
`:text` tag with the intent to use the existing containers default text color
* supports `\e[7m` which is background/forground swap. Attempts to do the swap
if the next token starts with a color. Otherwise ignores it