### PR TITLE
Add support ANSI 38 and 48 for 8 and 24 bit colors

### DIFF
--- a/test/ansi_to_html_test.exs
+++ b/test/ansi_to_html_test.exs
@@ -3,6 +3,7 @@ defmodule AnsiToHTMLTest do
   doctest AnsiToHTML
 
   import AnsiToHTML
+  import ExUnit.CaptureLog
 
   @pretty_inspect inspect :hello, pretty: true, syntax_colors: [atom: :green]
 
@@ -41,5 +42,38 @@ defmodule AnsiToHTMLTest do
           34]], 62,
         [[60, "pre", [[32, "class", 61, 34, "green", 34]], 62, [":hello"],
           60, 47, "pre", 62]], 60, 47, "code", 62]}
+  end
+
+  test "supports e[38;5;nm 8 bit coloring" do
+    color_line = IO.ANSI.color(228) <> "Howdy Partner"
+    assert AnsiToHTML.generate_html(color_line) ==
+      "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><span style=\"color: rgb(255, 255, 102);\">Howdy Partner</span></pre>"
+  end
+
+  test "supports e[38;2;r;g;bm 24 bit coloring" do
+    color_line = IO.ANSI.color(5, 5, 2) <> "Howdy Partner"
+    assert AnsiToHTML.generate_html(color_line) ==
+      "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><span style=\"color: rgb(255, 255, 102);\">Howdy Partner</span></pre>"
+  end
+
+  test "supports e[48;5;nm 8 bit background coloring" do
+    color_line = IO.ANSI.color_background(228) <> "Howdy Partner"
+    assert AnsiToHTML.generate_html(color_line) ==
+      "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><span style=\"background-color: rgb(255, 255, 102);\">Howdy Partner</span></pre>"
+  end
+
+  test "supports e[48;2;r;g;bm 24 bit background coloring" do
+    color_line = IO.ANSI.color_background(5, 5, 2) <> "Howdy Partner"
+    assert AnsiToHTML.generate_html(color_line) ==
+      "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><span style=\"background-color: rgb(255, 255, 102);\">Howdy Partner</span></pre>"
+    end
+
+  test "defaults to no styling if ANSI code not recognized" do
+    color_line = "\e[1234m Howdy Partner"
+    log_output = capture_log(fn ->
+      assert AnsiToHTML.generate_html(color_line) ==
+        "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><text> Howdy Partner</text></pre>"
+    end)
+    log_output =~ "[AnsiToHTML] ignoring unsupported ANSI style - \"\\e[1234m\"\n\e[0m"
   end
 end


### PR DESCRIPTION
Adds support for `\e[38;2;r;g;bm`, `\e[38;5;nm`, `\e[48;5;nm`, and `\e[48;2;r;g;bm`
codes which are 24 bit RGB and 8bit Xterm codes for the text (38) and background (48)

Also adds a little extra protection when no styling is defined in the theme and the
ANSI code is not recognized so it doesn't totally crash.