### PR TITLE
Implements Font Effects

### DIFF
--- a/test/ansi_to_html_test.exs
+++ b/test/ansi_to_html_test.exs
@@ -101,6 +101,14 @@ defmodule AnsiToHTMLTest do
              "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><span style=\"background-color: rgb(255, 255, 102);\">Howdy Partner</span></pre>"
   end
 
+  test "supports e[1;31m 4 bit coloring" do
+    color_line = "\e[1;31m" <> "Howdy Partner"
+
+    assert AnsiToHTML.generate_html(color_line) ==
+             "<pre style=\"font-family: monospace; font-size: 12px; padding: 4px; background-color: black; color: white;\"><span style=\"font-weight: bold;color: red;\">Howdy Partner</span></pre>"
+  end
+
+
   test "defaults to no styling if ANSI code not recognized" do
     color_line = "\e[1234m Howdy Partner"
 


### PR DESCRIPTION
Hi @stephlow,

First off, I want to say that I really appreciate your work on this repository! I recently came across it while working on a project where I need to execute binaries using Elixir and display their output on an HTML page. Your project provided an excellent foundation for converting ANSI to HTML—thank you!

However, I encountered an issue when trying to display certain effect/color combinations (like \e[1;31m, which represents bold red text). This PR addresses that issue by splitting up the various escape codes and converting them to integers. It also handles combined escape codes, such as 8-bit and 24-bit RGB, through recursive calls that account for the color mode and how many additional entries should be processed from the escape codes.

Please let me know if there are any adjustments you'd like to see to align this PR with the overall direction of the repository. I'm happy to make changes!

Thanks again for your work on this project.